### PR TITLE
chore(ci): oven-sh/setup-bun アクションを v2.2.0 に更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: latest
       - name: Install dependencies


### PR DESCRIPTION
Node 24 対応のため