### PR TITLE
chore: zod の import を `astro/zod` からに変更

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection } from 'astro:content';
 import { file, glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const note = defineCollection({
   loader: glob({ pattern: '*.md', base: './src/content/note' }),


### PR DESCRIPTION
Astro v6 で deprecated した